### PR TITLE
Add multiple offer pictures support

### DIFF
--- a/lib/goods/element.rb
+++ b/lib/goods/element.rb
@@ -66,7 +66,7 @@ module Goods
 
     def setup_instance_variable(name, type)
       case type
-      when :string
+      when :string, :array
         instance_variable_set("@#{name}", @info_hash[name])
       when :float
         instance_variable_set("@#{name}", @info_hash[name].to_f)

--- a/lib/goods/offer.rb
+++ b/lib/goods/offer.rb
@@ -4,6 +4,7 @@ module Goods
     attr_field :category_id, :currency_id, :available, :description,
                :model, :name, :picture, :vendor, :url
     attr_field :price, type: :float
+    attr_field :pictures, type: :array
 
     def convert_currency(other_currency)
       self.price *= currency.in(other_currency)

--- a/lib/goods/xml.rb
+++ b/lib/goods/xml.rb
@@ -125,9 +125,17 @@ module Goods
         offer_hash[property] = extract_text(offer, xpath)
       end
 
+      offer_hash[:pictures] = extract_multiple_elements(offer, "picture")
+
       offer_hash[:price] = extract_text(offer, "price").to_f
 
       offer_hash
+    end
+
+    def extract_multiple_elements(node, element_name)
+      node.xpath(element_name).map do |element|
+        extract_text(element)
+      end
     end
 
     def extract_attribute(node, attribute, default = nil)

--- a/spec/goods/offer_spec.rb
+++ b/spec/goods/offer_spec.rb
@@ -42,7 +42,7 @@ describe Goods::Offer do
     end
   end
 
-  [:available, :description, :model, :name, :picture, :vendor].each do |field|
+  [:available, :description, :model, :name, :picture, :pictures, :vendor].each do |field|
     it "should have #{field}" do
       expect(valid_offer).to respond_to(field)
     end

--- a/spec/goods/offers_list_spec.rb
+++ b/spec/goods/offers_list_spec.rb
@@ -13,12 +13,19 @@ describe Goods::OffersList do
     end
 
   describe "#add" do
+    let (:urls) {['url1', 'url2', 'url3']}
+    let (:offer) {Goods::Offer.new(id: "1", url: "url.com", category_id: "1", currency_id: "RUR", price: 10, pictures: urls)}
+
     it "should setup category and currency for offer" do
-      offer = Goods::Offer.new(id: "1", url: "url.com", category_id: "1", currency_id: "RUR", price: 10)
       subject.add(offer)
 
       expect(offer.category).to be(categories.find("1"))
       expect(offer.currency).to be(currencies.find("RUR"))
+    end
+
+    it "should setup pictures array for offer" do
+      expect(offer.pictures).to be_an(Array)
+      expect(offer.pictures).to contain_exactly(*urls)
     end
   end
 

--- a/spec/goods/xml_spec.rb
+++ b/spec/goods/xml_spec.rb
@@ -154,6 +154,10 @@ describe Goods::XML do
         expect(printer[:picture]).to eq("http://magazin.ru/img/device1.jpg")
       end
 
+      it "should set pictures array" do
+        expect(printer[:pictures].count).to eq(2)
+      end
+
       it "should have a nil picture if offer doesn't have one" do
         expect(book[:picture]).to be_nil
       end


### PR DESCRIPTION
According this spec http://help.yandex.ru/partnermarket/picture.xml, one **offer** element may contain multiple **picture** elements.
